### PR TITLE
Reduced source code length from 215 lines to 55 lines

### DIFF
--- a/contracts/Falcon.sol
+++ b/contracts/Falcon.sol
@@ -563,11 +563,68 @@ contract Falcon
     // KeccakF1600_StatePermute()
     // Input parameters supplied in member variable shake256_context64.
     // Output values are written to the same member variable.
+    // @ NOTE: The implementation has been updated by Mulliganaceous, but not tested for compile errors.
     ////////////////////////////////////////
+
+    function perform_KeccakF1600Round(uint64[][] A, uint64[][] E, uint64[] BC, uint64[] D, uint8[][] G) {
+        /* Mulliganaceous' modified Keccak function */
+        // Produce the initial BC and D vector
+        for (uint8 k = 0; k < 5; k++)
+            BC[k] = (A[0][k] ^ A[1][k] ^ A[2][k] ^ A[3][k] ^ A[4][k]);
+        for (uint8 k = 0; k < 5; k++)
+            D[k] = BC[(k - 1) % 5] ^ (((BC[(k + 1) % 5], 1) << 1) ^ ((BC[(k + 1) % 5], 1) >> (63)));
+            
+        // Ex: Note k is from {a,e,i,o,u} or {b,g,k,m,s}
+        uint8 offset = 0;
+        for (uint8 j = 0; j < 5; j++) {
+            for (uint8 k = 0; k < 5; k++) {
+                uint8 koffset = (k + offset) % 5;
+                A[k][koffset] ^= D[koffset];
+                BC[k] = (A[k][koffset] << G[k][koffset]) ^ (A[k][koffset] >> (64 - G[k][koffset]));
+            }
+            for (uint8 k = 0; k < 5; k++) {
+                uint8 koffset = (k + offset) % 5;
+                E[j][k] = BC[k] ^ (~BC[(k + 1)%5] & BC[(k + 2)%5]);
+            }
+            offset += 3;
+        }
+    }
+
     function KeccakF1600_StatePermute() public payable
     {
-        int         round;
+        // Deep copy A
+        uint64[5][5] A;
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                A[i][j] = shake256_context64[5*i + j];
+            }
+        }
+        uint8[][] G = [[ 0, 1,62,28,27],
+                       [36,44, 6,55,20],
+                       [ 3,10,43,25,39],
+                       [41,45,15,21, 8],
+                       [18, 2,61,56,14]];
+        uint64[5][5] E;
+        uint64[5] BC;
+        uint64[5] D;
 
+        // Perform loops
+        for (uint32 round = 0; round < NROUNDS; round += 2) {
+            perform_KeccakF1600Round(A, E, BC, D, G);
+            E[0][0] ^= KeccakF_RoundConstants[uint256(round)];
+            perform_KeccakF1600Round(E, A, BC, D, G);
+            A[0][0] ^= KeccakF_RoundConstants[uint256(round + 1)];
+        }
+
+        // Copy back
+        for (uint i8 = 0; i < 5; i++) {
+            for (uint8 j = 0; j < 5; j++) {
+                shake256_context64[5*i + j] = A[i][j];
+            }
+        }
+
+    /*  NOT USED ANYMORE
+        int         round;
         // copyFromState(A, state)
         Aba = shake256_context64[ 0]; Abe = shake256_context64[ 1]; Abi = shake256_context64[ 2]; Abo = shake256_context64[ 3]; Abu = shake256_context64[ 4];
         Aga = shake256_context64[ 5]; Age = shake256_context64[ 6]; Agi = shake256_context64[ 7]; Ago = shake256_context64[ 8]; Agu = shake256_context64[ 9];
@@ -778,7 +835,12 @@ contract Falcon
         shake256_context64[10] = Aka; shake256_context64[11] = Ake; shake256_context64[12] = Aki; shake256_context64[13] = Ako; shake256_context64[14] = Aku;
         shake256_context64[15] = Ama; shake256_context64[16] = Ame; shake256_context64[17] = Ami; shake256_context64[18] = Amo; shake256_context64[19] = Amu;
         shake256_context64[20] = Asa; shake256_context64[21] = Ase; shake256_context64[22] = Asi; shake256_context64[23] = Aso; shake256_context64[24] = Asu;
+        */
     }
+    // function KeccakF1600_StatePermute() public payable
+    // {
+
+    // }
 
     ////////////////////////////////////////
     //


### PR DESCRIPTION
The code is compressed into a double loop with an auxiliary G matrix.
Hope the compiled code savings offset the overhead of initializing the loop.